### PR TITLE
Fix ellipsis in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fix The Web
 
-> Let's fix it together.. One line at a time!
+> Let's fix it together... One line at a time!
 
 ## What is this?
 


### PR DESCRIPTION
Ellipses usually have 3 consecutive dots (`...`) instead of the previous 2 (`..`) that were present in the README.

(speaking of OCD... 😉)